### PR TITLE
[FEATURE] Remove deprecated models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # sambanova-ai-provider
 
+## 1.1.2
+
+### Patch Changes
+
+- Remove deprecated models
+- Update vite version
+
 ## 1.1.1
 
 ### Patch Changes

--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ You can use the following optional settings to customize the SambaNova provider 
 ## Models
 
 You can use [SambaNova models](https://docs.sambanova.ai/cloud/docs/get-started/supported-models) on the provider instance.
-The first argument is the model ID, e.g. `Meta-Llama-3.1-70B-Instruct`.
+The first argument is the model ID, e.g. `Meta-Llama-3.3-70B-Instruct`.
 
 ```ts
-const model = sambanova('Meta-Llama-3.1-70B-Instruct');
+const model = sambanova('Meta-Llama-3.3-70B-Instruct');
 ```
 
 ### Tested models and capabilities

--- a/examples/image-input.md
+++ b/examples/image-input.md
@@ -17,7 +17,7 @@ const { text } = await generateText({
       role: 'user',
       content: [
         { type: 'text', text: 'Describe the image in detail and review it' },
-        { image: fs.readFileSync('./solar.jpg'), type: 'image' },
+        { image: fs.readFileSync('./example-image.jpg'), type: 'image' },
       ],
     },
   ],

--- a/examples/text-generation.md
+++ b/examples/text-generation.md
@@ -8,7 +8,7 @@ import { generateText } from 'ai';
 import dotenv from 'dotenv';
 
 const { text } = await generateText({
-  model: sambanova('Meta-Llama-3.1-70B-Instruct'),
+  model: sambanova('Meta-Llama-3.3-70B-Instruct'),
   prompt: 'Hello, nice to meet you.',
 });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sambanova-ai-provider",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Vercel AI Provider for running LLMs locally using SambaNova models",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -47,7 +47,7 @@
     "prettier": "3.5.3",
     "tsup": "^8.4.0",
     "typescript": "^5.8.2",
-    "vite": "^6.2.2",
+    "vite": "^6.2.6",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.8",
     "zod": "^3.24.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,11 +73,11 @@ importers:
         specifier: ^5.8.2
         version: 5.8.3
       vite:
-        specifier: ^6.2.2
-        version: 6.2.5(@types/node@22.14.0)
+        specifier: ^6.2.6
+        version: 6.2.6(@types/node@22.14.0)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0))
+        version: 5.1.4(typescript@5.8.3)(vite@6.2.6(@types/node@22.14.0))
       vitest:
         specifier: ^3.0.8
         version: 3.1.1(@edge-runtime/vm@5.0.0)(@types/node@22.14.0)
@@ -1987,8 +1987,8 @@ packages:
       vite:
         optional: true
 
-  vite@6.2.5:
-    resolution: {integrity: sha512-j023J/hCAa4pRIUH6J9HemwYfjB5llR2Ps0CWeikOtdR8+pAURAk0DoJC5/mm9kd+UgdnIy7d6HE4EAvlYhPhA==}
+  vite@6.2.6:
+    resolution: {integrity: sha512-9xpjNl3kR4rVDZgPNdTL0/c6ao4km69a/2ihNQbcANz8RuCOK3hQBmLSJf3bRKVQjVMda+YvizNE8AwvogcPbw==}
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
     peerDependencies:
@@ -2632,13 +2632,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.1(vite@6.2.5(@types/node@22.14.0))':
+  '@vitest/mocker@3.1.1(vite@6.2.6(@types/node@22.14.0))':
     dependencies:
       '@vitest/spy': 3.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.2.5(@types/node@22.14.0)
+      vite: 6.2.6(@types/node@22.14.0)
 
   '@vitest/pretty-format@3.1.1':
     dependencies:
@@ -4142,7 +4142,7 @@ snapshots:
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.2.5(@types/node@22.14.0)
+      vite: 6.2.6(@types/node@22.14.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4157,18 +4157,18 @@ snapshots:
       - tsx
       - yaml
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@6.2.5(@types/node@22.14.0)):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@6.2.6(@types/node@22.14.0)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2
       tsconfck: 3.1.5(typescript@5.8.3)
     optionalDependencies:
-      vite: 6.2.5(@types/node@22.14.0)
+      vite: 6.2.6(@types/node@22.14.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.2.5(@types/node@22.14.0):
+  vite@6.2.6(@types/node@22.14.0):
     dependencies:
       esbuild: 0.25.2
       postcss: 8.5.3
@@ -4180,7 +4180,7 @@ snapshots:
   vitest@3.1.1(@edge-runtime/vm@5.0.0)(@types/node@22.14.0):
     dependencies:
       '@vitest/expect': 3.1.1
-      '@vitest/mocker': 3.1.1(vite@6.2.5(@types/node@22.14.0))
+      '@vitest/mocker': 3.1.1(vite@6.2.6(@types/node@22.14.0))
       '@vitest/pretty-format': 3.1.1
       '@vitest/runner': 3.1.1
       '@vitest/snapshot': 3.1.1
@@ -4196,7 +4196,7 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.2.5(@types/node@22.14.0)
+      vite: 6.2.6(@types/node@22.14.0)
       vite-node: 3.1.1(@types/node@22.14.0)
       why-is-node-running: 2.3.0
     optionalDependencies:

--- a/src/sambanova-chat-settings.ts
+++ b/src/sambanova-chat-settings.ts
@@ -3,23 +3,17 @@
 export type SambaNovaChatModelId =
   | 'DeepSeek-R1'
   | 'DeepSeek-R1-Distill-Llama-70B'
-  | 'Llama-3.1-Tulu-3-405B'
+  | 'DeepSeek-V3-0324'
   | 'Llama-4-Maverick-17B-128E-Instruct'
   | 'Llama-4-Scout-17B-16E-Instruct'
   | 'Meta-Llama-3.3-70B-Instruct'
   | 'Meta-Llama-3.2-3B-Instruct'
   | 'Meta-Llama-3.2-1B-Instruct'
   | 'Meta-Llama-3.1-405B-Instruct'
-  | 'Meta-Llama-3.1-70B-Instruct'
   | 'Meta-Llama-3.1-8B-Instruct'
   | 'Meta-Llama-3.2-90B-Vision-Instruct'
   | 'Meta-Llama-3.2-11B-Vision-Instruct'
-  | 'Qwen2.5-Coder-32B-Instruct'
-  | 'Qwen2.5-72B-Instruct'
   | 'QwQ-32B'
-  | 'Qwen2-Audio-7B-Instruct'
-  | 'Llama-3.1-Swallow-8B-Instruct-v0.3'
-  | 'Llama-3.1-Swallow-70B-Instruct-v0.3'
   | (string & {});
 
 export interface SambaNovaChatSettings {


### PR DESCRIPTION
<!-- You must fill out the information below before this pull request can be reviewed.
By providing a short description and listing the changes you've made (or optionally linking to an issue), it can be reviewed more easily. -->

## Short description
Based on the [April 14th model deprecations](https://docs.sambanova.ai/cloud/docs/resources/deprecations#april-14%2C-2025), remove these models and add their replacements.

<!-- If available, include any code snippets, screenshots, or gifs. -->

## Additions, changes, and/or deletions

This PR removes:
- Deprecated models.
  - Llama-3.1-Tulu-3-405B
  - Llama-3.1-Swallow-70B-Instruct-v0.3
  - Meta-Llama-3.1-70B-Instruct
  - Qwen2.5-72B-Instruct
  - Qwen2.5-Coder-32B-Instruct

This PR adds:
- New model replacements.
  - DeepSeek-V3-0324

## Issue(s) this PR Closes

<!-- If there's an existing issue for your change, please add a link to it below. -->

Closes #5.

## Additional notes

<!-- If it applies. If not, remove this section. -->

- To be applied on April 14th, 2025.
- Vision models weren't deprecated but they're marked as they're going to be.
- Llama-3.1-Swallow-70B-Instruct-v0.4 isn't available yet.