### PR TITLE
Fix Usage response for stream

### DIFF
--- a/src/sambanova-chat-language-model.test.ts
+++ b/src/sambanova-chat-language-model.test.ts
@@ -1040,6 +1040,9 @@ describe('doStream', () => {
       stream: true,
       model: modelName,
       messages: [{ role: 'user', content: 'Hello' }],
+      stream_options: {
+        include_usage: true,
+      },
     });
   });
 

--- a/src/sambanova-chat-language-model.ts
+++ b/src/sambanova-chat-language-model.ts
@@ -271,6 +271,7 @@ export class SambaNovaChatLanguageModel implements LanguageModelV1 {
       body: {
         ...args,
         stream: true,
+        stream_options: { include_usage: true },
       },
       failedResponseHandler: sambaNovaFailedResponseHandler,
       successfulResponseHandler: createEventSourceResponseHandler(


### PR DESCRIPTION

## Short description
Fixes an issue where SambaNova streaming responses were returning `{ promptTokens: NaN, completionTokens: NaN, totalTokens: NaN }` in the `onFinish` callback when using the Vercel AI SDK.  
This PR ensures correct token usage tracking during streaming by including `stream_options: { include_usage: true }` in the request payload.

## Additions, changes, and/or deletions
- Modified `doStream` to add `stream_options: { include_usage: true }` when initiating the `/chat/completions` streaming request.
- Preserved existing behavior for other models and providers.

## Issue(s) this PR Closes
(https://github.com/sambanova/sambanova-ai-provider/issues/14)


